### PR TITLE
Two-staged RecSync workflow

### DIFF
--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -39,6 +39,7 @@ import com.googleresearch.capturesync.softwaresync.phasealign.PeriodCalculator;
 
 import net.sourceforge.opencamera.MainActivity;
 import net.sourceforge.opencamera.R;
+import net.sourceforge.opencamera.recsync.SoftwareSyncUtils;
 import net.sourceforge.opencamera.recsync.SyncSettingsContainer;
 
 import java.io.Closeable;
@@ -210,8 +211,9 @@ public class SoftwareSyncController implements Closeable {
 
                     if (settings != null) {
                         mState = State.SETTINGS_APPLICATION;
-                        mMainActivity.getApplicationInterface().getSoftwareSyncUtils().applyAndLockSettings(settings, () -> {
-                            mMainActivity.getApplicationInterface().getSoftwareSyncUtils().prepareVideoRecording();
+                        SoftwareSyncUtils softwareSyncUtils = mMainActivity.getApplicationInterface().getSoftwareSyncUtils();
+                        softwareSyncUtils.applyAndLockSettings(settings, () -> {
+                            softwareSyncUtils.prepareVideoRecording();
                             mIsVideoPreparationNeeded = true;
                             Log.d(TAG, "Settings application finished");
                             mState = State.IDLE;
@@ -479,7 +481,7 @@ public class SoftwareSyncController implements Closeable {
     }
 
     /**
-     * Shows whether is device is expected to be prepared for video recording.
+     * Shows whether this device is expected to be prepared for video recording.
      *
      * @return true if video recording preparation is expected, false otherwise.
      */

--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -247,7 +247,6 @@ public class SoftwareSyncController implements Closeable {
                     }
                     if (mMainActivity.getPreview().isVideoRecording() == Boolean.parseBoolean(payload)) {
                         if (mState == State.RECORDING) { // Need to stop recording.
-                            mIsPeriodCalculated = false;
                             mMainActivity.runOnUiThread(() -> {
                                 mMainActivity.takePicturePressed(false, false);
                                 mMainActivity.getApplicationInterface().getSoftwareSyncUtils().prepareVideoRecording(); // Prepare to the next recording

--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -213,6 +213,7 @@ public class SoftwareSyncController implements Closeable {
                         mState = State.SETTINGS_APPLICATION;
                         mMainActivity.getApplicationInterface().getSoftwareSyncUtils().applyAndLockSettings(settings, () -> {
                             mMainActivity.getApplicationInterface().getSoftwareSyncUtils().prepareVideoRecording();
+                            Log.d(TAG, "Settings application finished");
                             mState = State.IDLE;
                         });
                     }
@@ -338,6 +339,8 @@ public class SoftwareSyncController implements Closeable {
         @RequiresApi(api = Build.VERSION_CODES.N)
         @Override
         protected Void doInBackground(Void... voids) {
+            Log.d(TAG, "Starting AlignPhasesTask");
+
             if (mSoftwareSyncController.mState != State.IDLE) {
                 Log.d(TAG, "Period calculation and phase alignment cannot be started at state " +
                         mSoftwareSyncController.mState);

--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -249,7 +249,6 @@ public class SoftwareSyncController implements Closeable {
                         if (mState == State.RECORDING) { // Need to stop recording.
                             mMainActivity.runOnUiThread(() -> {
                                 mMainActivity.takePicturePressed(false, false);
-                                mMainActivity.getApplicationInterface().getSoftwareSyncUtils().prepareVideoRecording(); // Prepare to the next recording
                                 mState = State.IDLE;
                             });
                         } else { // Need to start recording.

--- a/app/src/main/java/com/googleresearch/capturesync/softwaresync/phasealign/PeriodCalculator.java
+++ b/app/src/main/java/com/googleresearch/capturesync/softwaresync/phasealign/PeriodCalculator.java
@@ -51,8 +51,9 @@ public class PeriodCalculator {
 
     @RequiresApi(api = Build.VERSION_CODES.N)
     private List<Long> getDiff(ArrayList<Long> list) {
+        // TODO: check if filtering remains necessary after phase alignment gets fixed.
         List<Long> result = StreamUtils.zip(list.stream(), list.stream().skip(1),
-                (Long x, Long y) -> y - x).collect(Collectors.toList());
+                (Long x, Long y) -> y - x).filter(it -> it != 0L).collect(Collectors.toList());
         return result;
     }
 

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -249,6 +249,13 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         }
 
         super.stoppingVideo();
+
+        if (isSoftwareSyncRunning() && !mSoftwareSyncController.isLeader()) {
+            ImageButton view = mMainActivity.findViewById(R.id.take_photo);
+            view.setImageResource(R.drawable.ic_empty);
+            view.setContentDescription(mMainActivity.getResources().getString(R.string.do_nothing));
+            view.setTag(R.drawable.ic_empty); // for testing
+        }
     }
 
     @Override
@@ -256,7 +263,8 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         super.stoppedVideo(video_method, uri, filename);
 
         // Prepare to the next recording
-        if (mSoftwareSyncController.isVideoPreparationNeeded()) mSoftwareSyncUtils.prepareVideoRecording();
+        if (mSoftwareSyncController.isVideoPreparationNeeded())
+            mSoftwareSyncUtils.prepareVideoRecording();
     }
 
     public void onFrameInfoRecordingFailed() {

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -92,12 +92,11 @@ public class ExtendedAppInterface extends MyApplicationInterface {
     }
 
     /**
-     * Create {@link VideoFrameInfo} with the current preferences.
+     * Creates an unprepared {@link VideoFrameInfo} with the current preferences.
      *
      * @return the created {@link VideoFrameInfo}.
-     * @throws IOException if unable to create files for timestamps recording.
      */
-    public VideoFrameInfo setupFrameInfo() throws IOException {
+    public VideoFrameInfo setupFrameInfo() {
         return new VideoFrameInfo(
                 getLastVideoDate(),
                 mMainActivity,
@@ -182,6 +181,7 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         if (MyDebug.LOG) {
             Log.d(TAG, "starting video");
         }
+
         if (mPrefs.isIMURecordingEnabled() && useCamera2() && (mPrefs.isGyroEnabled() || mPrefs.isAccelEnabled() || mPrefs.isMagneticEnabled())) {
             // Extracting sample rates from shared preferences
             try {

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -8,6 +8,7 @@ import android.content.IntentFilter;
 import android.hardware.Sensor;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -248,6 +249,14 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         }
 
         super.stoppingVideo();
+    }
+
+    @Override
+    public void stoppedVideo(VideoMethod video_method, Uri uri, String filename) {
+        super.stoppedVideo(video_method, uri, filename);
+
+        // Prepare to the next recording
+        if (mSoftwareSyncController.isVideoPreparationNeeded()) mSoftwareSyncUtils.prepareVideoRecording();
     }
 
     public void onFrameInfoRecordingFailed() {

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -157,8 +157,12 @@ public class ExtendedAppInterface extends MyApplicationInterface {
     }
 
     public void cameraOpened() {
-        // Should be at the end of this method as it may close the camera
         if (isSoftwareSyncRunning()) {
+            if (mSoftwareSyncController.isVideoPreparationNeeded()) {
+                mSoftwareSyncUtils.prepareVideoRecording();
+            }
+
+            // Should be at the end of this method as it may close the camera
             final Runnable applySettingsRunnable = mSoftwareSyncUtils.getApplySettingsRunnable();
             if (applySettingsRunnable != null) {
                 applySettingsRunnable.run();

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1830,6 +1830,8 @@ public class MainActivity extends Activity {
             settings = SyncSettingsContainer.buildFrom(this);
             applicationInterface.getSoftwareSyncUtils().scheduleBroadcastSettings(settings); // leader's settings are locked here as well
             preview.showToast(rec_sync_toast, R.string.settings_broadcast_started);
+        } else {
+            softwareSyncController.clearPeriodState();
         }
 
         softwareSyncController.switchSettingsLock(settings);
@@ -2447,6 +2449,10 @@ public class MainActivity extends Activity {
         applicationInterface.stopPanorama(true); // important to stop panorama recording, as we might end up as we'll be changing camera parameters when the settings window closes
         stopAudioListeners();
 
+        if( applicationInterface.isSoftwareSyncRunning() ) {
+            applicationInterface.getSoftwareSyncController().clearPeriodState();
+        }
+
         Bundle bundle = new Bundle();
         bundle.putBoolean(PreferenceKeys.SupportsGyroKey, mRawSensorInfo.isSensorAvailable(Sensor.TYPE_GYROSCOPE));
         bundle.putBoolean(PreferenceKeys.SupportsAccelKey, mRawSensorInfo.isSensorAvailable(Sensor.TYPE_ACCELEROMETER));
@@ -2990,6 +2996,8 @@ public class MainActivity extends Activity {
                 mainUI.destroyPopup();
             }
         }
+
+        // TODO: check if RecSync is running and camera needs to be prepared
     }
 
     @Override

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -2456,6 +2456,7 @@ public class MainActivity extends Activity {
 
         if( applicationInterface.isSoftwareSyncRunning() ) {
             applicationInterface.getSoftwareSyncController().clearPeriodState();
+            applicationInterface.getSoftwareSyncUtils().removeVideoRecordingPreparation();
         }
 
         Bundle bundle = new Bundle();
@@ -3000,10 +3001,6 @@ public class MainActivity extends Activity {
                 // sync (e.g., changing the Repeat Mode)
                 mainUI.destroyPopup();
             }
-        }
-
-        if( applicationInterface.isSoftwareSyncRunning() && applicationInterface.getSoftwareSyncController().isVideoPreparationNeeded() ) {
-            applicationInterface.getSoftwareSyncUtils().prepareVideoRecording();
         }
     }
 

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1836,6 +1836,7 @@ public class MainActivity extends Activity {
             preview.showToast(rec_sync_toast, R.string.settings_broadcast_started);
         } else {
             softwareSyncController.clearPeriodState();
+            applicationInterface.getSoftwareSyncUtils().broadcastClearVideoPreparationRequest();
         }
 
         softwareSyncController.switchSettingsLock(settings);
@@ -3001,7 +3002,9 @@ public class MainActivity extends Activity {
             }
         }
 
-        // TODO: check if RecSync is running and camera needs to be prepared
+        if( applicationInterface.isSoftwareSyncRunning() && applicationInterface.getSoftwareSyncController().isVideoPreparationNeeded() ) {
+            applicationInterface.getSoftwareSyncUtils().prepareVideoRecording();
+        }
     }
 
     @Override

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1549,6 +1549,12 @@ public class MainActivity extends Activity {
         super.onPause(); // docs say to call this before freeing other things
         this.app_is_paused = true;
 
+        // clear RecSync related state
+        if( applicationInterface.isSoftwareSyncRunning() ) {
+            applicationInterface.getSoftwareSyncController().clearPeriodState();
+            applicationInterface.getSoftwareSyncUtils().removeVideoRecordingPreparation();
+        }
+
         // Stop Remote controller for OpenCamera Sensors
         if (mRpcServer != null) {
             mRpcServer.stopExecuting();

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1832,7 +1832,7 @@ public class MainActivity extends Activity {
 
         if( !softwareSyncController.isSettingsBroadcasting() ) {
             settings = SyncSettingsContainer.buildFrom(this);
-            applicationInterface.getSoftwareSyncUtils().scheduleBroadcastSettings(settings); // leader's settings are locked here as well
+            applicationInterface.getSoftwareSyncUtils().broadcastSettings(settings); // leader's settings are locked here as well
             preview.showToast(rec_sync_toast, R.string.settings_broadcast_started);
         } else {
             softwareSyncController.clearPeriodState();

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1810,9 +1810,13 @@ public class MainActivity extends Activity {
         syncSettings();
         mainUI.updateSyncSettingsIcon();
 
-        // need to update alignPhases button visibility
-        View button = findViewById(R.id.align_phases);
-        button.setVisibility(mainUI.showAlignPhasesIcon() ? View.VISIBLE : View.GONE);
+        // need to update button visibility
+        if( mainUI.inImmersiveMode() ) {
+            mainUI.setImmersiveMode(true);
+        } else {
+            mainUI.showGUI();
+        }
+        mainUI.layoutUI();
     }
 
     public void syncSettings() {
@@ -4882,7 +4886,11 @@ public class MainActivity extends Activity {
         // However still nee to update visibility of icons where visibility depends on camera setup - e.g., exposure button
         // not supported for high speed video frame rates - see testTakeVideoFPSHighSpeedManual().
         View exposureButton = findViewById(R.id.exposure);
-        exposureButton.setVisibility(supportsExposureButton() && !mainUI.inImmersiveMode() ? View.VISIBLE : View.GONE);
+        {
+            SoftwareSyncController softwareSyncController = applicationInterface.getSoftwareSyncController();
+            exposureButton.setVisibility(supportsExposureButton() && !mainUI.inImmersiveMode() &&
+                    !(applicationInterface.isSoftwareSyncRunning() && softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting()) ? View.VISIBLE : View.GONE);
+        }
 
         // needed as availability of some icons is per-camera (e.g., flash, RAW)
         // for making icons visible, this is done elsewhere in call to MainUI.showGUI()

--- a/app/src/main/java/net/sourceforge/opencamera/cameracontroller/CameraController2.java
+++ b/app/src/main/java/net/sourceforge/opencamera/cameracontroller/CameraController2.java
@@ -1261,7 +1261,7 @@ public class CameraController2 extends CameraController {
         @Override
         public void onImageAvailable(ImageReader reader) {
             if (MyDebug.LOG) {
-                Log.d(TAG, "Frame during video recording");
+                Log.d(TAG, "new video frame available");
             }
             Image image = reader.acquireNextImage();
 
@@ -1285,7 +1285,7 @@ public class CameraController2 extends CameraController {
             }
 
             if (MyDebug.LOG) {
-                Log.d(TAG, "Released frame during video recording");
+                Log.d(TAG, "released video frame");
             }
             image.close();
         }

--- a/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
+++ b/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
@@ -5559,7 +5559,6 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 
             profile.copyToMediaRecorder(local_video_recorder);
 
-            //boolean told_app_starting = false; // true if we called applicationInterface.startingVideo()
             try {
                 ApplicationInterface.VideoMaxFileSize video_max_filesize = applicationInterface.getVideoMaxFileSizePref();
                 long max_filesize = video_max_filesize.max_filesize;
@@ -5607,10 +5606,7 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
                 else {
                     local_video_recorder.setOutputFile(videoFileInfo.video_pfd_saf.getFileDescriptor());
                 }
-                //applicationInterface.cameraInOperation(true, true);
-                //told_app_starting = true;
-                //applicationInterface.startingVideo();
-        		/*if( true ) // test
+                /*if( true ) // test
         			throw new IOException();*/
                 cameraSurface.setVideoRecorder(local_video_recorder);
 
@@ -5680,9 +5676,6 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
                     Log.e(TAG, "failed to save video");
                 e.printStackTrace();
                 this.video_recorder = local_video_recorder;
-                //if( told_app_starting ) {
-                //    applicationInterface.stoppingVideo();
-                //}
                 applicationInterface.onFailedCreateVideoFileError();
                 video_recorder.reset();
                 video_recorder.release();
@@ -5698,9 +5691,6 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
                     Log.e(TAG, "camera exception starting video recorder");
                 e.printStackTrace();
                 this.video_recorder = local_video_recorder; // still assign, so failedToStartVideoRecorder() will release the video_recorder
-                //if( told_app_starting ) {
-                //    applicationInterface.stoppingVideo();
-                //}
                 failedToStartVideoRecorder(profile);
             }
             catch(NoFreeStorageException e) {
@@ -5708,9 +5698,6 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
                     Log.e(TAG, "nofreestorageexception starting video recorder");
                 e.printStackTrace();
                 this.video_recorder = local_video_recorder;
-                //if( told_app_starting ) {
-                //    applicationInterface.stoppingVideo();
-                //}
                 video_recorder.reset();
                 video_recorder.release();
                 video_recorder = null;

--- a/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
+++ b/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
@@ -5478,7 +5478,7 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 
     private boolean prepareVideoRecording(final boolean max_filesize_restart, final MediaRecorder local_video_recorder, final VideoProfile profile) {
         if (MyDebug.LOG)
-            Log.d(TAG, "startVideoRecording");
+            Log.d(TAG, "prepareVideoRecording");
 
         boolean successful = false;
 
@@ -5742,20 +5742,24 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
         applicationInterface.cameraInOperation(true, true);
         applicationInterface.startingVideo();
 
-        try {
-            mVideoFrameInfoWriter.prepare();
-        } catch (IOException e) {
-            Log.e(TAG, "Exception preparing video frame info recorder");
-            e.printStackTrace();
-            applicationInterface.onFrameInfoRecordingFailed();
-            applicationInterface.stoppingVideo();
+        if( mVideoFrameInfoWriter != null ) {
+            Log.d(TAG, "preparing videoFrameInfoWriter");
 
-            video_recorder.reset();
-            video_recorder.release();
-            video_recorder = null;
-            video_recorder_is_paused = false;
-            applicationInterface.cameraInOperation(false, true);
-            this.reconnectCamera(true);
+            try {
+                mVideoFrameInfoWriter.prepare();
+            } catch (IOException e) {
+                Log.e(TAG, "Exception preparing video frame info recorder");
+                e.printStackTrace();
+                applicationInterface.onFrameInfoRecordingFailed();
+                applicationInterface.stoppingVideo();
+
+                video_recorder.reset();
+                video_recorder.release();
+                video_recorder = null;
+                video_recorder_is_paused = false;
+                applicationInterface.cameraInOperation(false, true);
+                this.reconnectCamera(true);
+            }
         }
 
         try {

--- a/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
+++ b/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
@@ -1025,7 +1025,6 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
         applicationInterface.cameraInOperation(false, true);
         reconnectCamera(false); // n.b., if something went wrong with video, then we reopen the camera - which may fail (or simply not reopen, e.g., if app is now paused)
 
-
         if( video_recorder == null ) {
             // no need to do anything if not recording
             // (important to exit, otherwise we'll momentarily switch the take photo icon to video mode in MyApplicationInterface.stoppingVideo() when opening the settings in landscape mode
@@ -5711,6 +5710,21 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
         }
 
         return successful;
+    }
+
+    public void removeVideoRecordingPreparation() {
+        if( MyDebug.LOG )
+            Log.d(TAG, "removeVideoRecordingPreparation");
+
+        prepared_video_recorder.reset();
+        prepared_video_recorder.release();
+        prepared_video_recorder = null;
+
+        prepared_video_profile = null;
+
+        applicationInterface.deleteUnusedVideo(videoFileInfo.video_method, videoFileInfo.video_uri, videoFileInfo.video_filename);
+
+        stopVideo(false);
     }
 
     /**

--- a/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
+++ b/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
@@ -93,8 +93,8 @@ public class SoftwareSyncUtils {
         Log.d(TAG, "Removing video recording preparation.");
 
         if (mPreview.isVideoRecordingPrepared()) {
-            Log.d(TAG, "About to call mPreview.stopVideo().");
-            mMainActivity.runOnUiThread(() -> mPreview.stopVideo(false));
+            Log.d(TAG, "About to call mPreview.removeVideoRecordingPreparation().");
+            mMainActivity.runOnUiThread(mPreview::removeVideoRecordingPreparation);
         }
     }
 

--- a/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
+++ b/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
@@ -2,7 +2,6 @@ package net.sourceforge.opencamera.recsync;
 
 import android.content.SharedPreferences;
 import android.os.Build;
-import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -29,7 +28,6 @@ public class SoftwareSyncUtils {
     private final ExtendedAppInterface mApplicationInterface;
     private final SoftwareSyncController mSoftwareSyncController;
 
-    private final Handler mSendSettingsHandler = new Handler();
     private Runnable mApplySettingsRunnable = null;
 
     public SoftwareSyncUtils(MainActivity mainActivity) {
@@ -72,33 +70,27 @@ public class SoftwareSyncUtils {
     }
 
     /**
-     * Schedules a broadcast of the current settings to clients. The settings will be applied to the
-     * leader too.
+     * Broadcasts the current settings to clients. The settings are applied to the leader too.
      *
      * @param settings describes the settings to be broadcast.
      * @throws IllegalStateException if after the delay {@link SoftwareSyncController} is not
      *                               initialized or this device is not a leader.
      */
-    public void scheduleBroadcastSettings(SyncSettingsContainer settings) {
-        mSendSettingsHandler.removeCallbacks(null);
-        mSendSettingsHandler.postDelayed(
-                () -> {
-                    Log.d(TAG, "Broadcasting current settings.");
+    public void broadcastSettings(SyncSettingsContainer settings) {
+        Log.d(TAG, "Broadcasting current settings.");
 
-                    if (!mApplicationInterface.isSoftwareSyncRunning()) {
-                        throw new IllegalStateException("Cannot broadcast settings when RecSync is not running");
-                    }
-                    if (!mSoftwareSyncController.isLeader()) {
-                        throw new IllegalStateException("Cannot broadcast settings from a client");
-                    }
+        if (!mApplicationInterface.isSoftwareSyncRunning()) {
+            throw new IllegalStateException("Cannot broadcast settings when RecSync is not running");
+        }
+        if (!mSoftwareSyncController.isLeader()) {
+            throw new IllegalStateException("Cannot broadcast settings from a client");
+        }
 
-                    // Send settings to all devices
-                    ((SoftwareSyncLeader) mSoftwareSyncController.getSoftwareSync()).broadcastRpc(
-                            SoftwareSyncController.METHOD_SET_SETTINGS,
-                            settings.serializeToString()
-                    );
-                },
-                500);
+        // Send settings to all devices
+        ((SoftwareSyncLeader) mSoftwareSyncController.getSoftwareSync()).broadcastRpc(
+                SoftwareSyncController.METHOD_SET_SETTINGS,
+                settings.serializeToString()
+        );
     }
 
     /**

--- a/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
+++ b/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
@@ -83,7 +83,7 @@ public class SoftwareSyncUtils {
         removeVideoRecordingPreparation(); // In case we want to re-prepare for some reason
 
         Log.d(TAG, "About to call Preview.prepareVideoRecording().");
-        mPreview.prepareVideoRecording();
+        mMainActivity.runOnUiThread(mPreview::prepareVideoRecording);
     }
 
     /**
@@ -94,7 +94,7 @@ public class SoftwareSyncUtils {
 
         if (mPreview.isVideoRecordingPrepared()) {
             Log.d(TAG, "About to call mPreview.stopVideo().");
-            mPreview.stopVideo(false);
+            mMainActivity.runOnUiThread(() -> mPreview.stopVideo(false));
         }
     }
 

--- a/app/src/main/java/net/sourceforge/opencamera/ui/MainUI.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ui/MainUI.java
@@ -1029,10 +1029,7 @@ public class MainUI {
     }
 
     public boolean showAlignPhasesIcon() {
-        final ExtendedAppInterface applicationInterface = main_activity.getApplicationInterface();
-        final SoftwareSyncController softwareSyncController = applicationInterface.getSoftwareSyncController();
-        return applicationInterface.getPrefs().isEnablePhaseAlignmentEnabled() && applicationInterface.isSoftwareSyncRunning() &&
-                softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting();
+        return main_activity.getApplicationInterface().getPrefs().isEnablePhaseAlignmentEnabled();
     }
 
     public boolean showStampIcon() {
@@ -1073,6 +1070,12 @@ public class MainUI {
                 // if going into immersive mode, the we should set GONE the ones that are set GONE in showGUI(false)
                 //final int visibility_gone = immersive_mode ? View.GONE : View.VISIBLE;
                 final int visibility = immersive_mode ? View.GONE : View.VISIBLE;
+                final int visibility_settings_sync; // for UI that is hidden when settings are being broadcast
+                {
+                    ExtendedAppInterface extendedAppInterface = main_activity.getApplicationInterface();
+                    SoftwareSyncController softwareSyncController = extendedAppInterface.getSoftwareSyncController();
+                    visibility_settings_sync = extendedAppInterface.isSoftwareSyncRunning() && softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting() ? View.GONE : visibility;
+                }
                 if( MyDebug.LOG )
                     Log.d(TAG, "setImmersiveMode: set visibility: " + visibility);
                 // n.b., don't hide share and trash buttons, as they require immediate user input for us to continue
@@ -1105,11 +1108,11 @@ public class MainUI {
                     switchMultiCameraButton.setVisibility(visibility);
                 switchVideoButton.setVisibility(visibility);
                 if( main_activity.supportsExposureButton() )
-                    exposureButton.setVisibility(visibility);
+                    exposureButton.setVisibility(visibility_settings_sync);
                 if( showAlignPhasesIcon() )
-                    alignPhasesButton.setVisibility(visibility);
+                    alignPhasesButton.setVisibility(visibility_settings_sync == View.GONE ? visibility : View.GONE); // is shown when settings are being broadcast
                 if( showExposureLockIcon() )
-                    exposureLockButton.setVisibility(visibility);
+                    exposureLockButton.setVisibility(visibility_settings_sync);
                 if( showWhiteBalanceLockIcon() )
                     whiteBalanceLockButton.setVisibility(visibility);
                 if( showCycleRawIcon() )
@@ -1130,7 +1133,7 @@ public class MainUI {
                     syncSettingsButton.setVisibility(visibility);
                 if( main_activity.hasAudioControl() )
                     audioControlButton.setVisibility(visibility);
-                popupButton.setVisibility(visibility);
+                popupButton.setVisibility(visibility_settings_sync);
                 galleryButton.setVisibility(visibility);
                 settingsButton.setVisibility(visibility);
                 if( MyDebug.LOG ) {
@@ -1206,6 +1209,14 @@ public class MainUI {
                 final boolean is_panorama_recording = main_activity.getApplicationInterface().getGyroSensor().isRecording();
                 final int visibility = is_panorama_recording ? View.GONE : (show_gui_photo && show_gui_video) ? View.VISIBLE : View.GONE; // for UI that is hidden while taking photo or video
                 final int visibility_video = is_panorama_recording ? View.GONE : show_gui_photo ? View.VISIBLE : View.GONE; // for UI that is only hidden while taking photo
+                final int visibility_settings_sync; // for UI that is hidden while taking photo or video and when settings are being broadcast
+                final int visibility_settings_sync_video; // for UI that is hidden while taking photo and when settings are being broadcast
+                {
+                    ExtendedAppInterface extendedAppInterface = main_activity.getApplicationInterface();
+                    SoftwareSyncController softwareSyncController = extendedAppInterface.getSoftwareSyncController();
+                    visibility_settings_sync = extendedAppInterface.isSoftwareSyncRunning() && softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting() ? View.GONE : visibility;
+                    visibility_settings_sync_video = extendedAppInterface.isSoftwareSyncRunning() && softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting() ? View.GONE : visibility_video;
+                }
                 View switchCameraButton = main_activity.findViewById(R.id.switch_camera);
                 View switchMultiCameraButton = main_activity.findViewById(R.id.switch_multi_camera);
                 View switchVideoButton = main_activity.findViewById(R.id.switch_video);
@@ -1229,11 +1240,11 @@ public class MainUI {
                     switchMultiCameraButton.setVisibility(visibility);
                 switchVideoButton.setVisibility(visibility);
                 if( main_activity.supportsExposureButton() )
-                    exposureButton.setVisibility(visibility_video); // still allow exposure when recording video
+                    exposureButton.setVisibility(visibility_settings_sync_video); // still allow exposure when recording video
                 if( showAlignPhasesIcon() )
-                    alignPhasesButton.setVisibility(visibility);
+                    alignPhasesButton.setVisibility(visibility_settings_sync == View.GONE ? visibility : View.GONE); // is shown when settings are being broadcast
                 if( showExposureLockIcon() )
-                    exposureLockButton.setVisibility(visibility_video); // still allow exposure lock when recording video
+                    exposureLockButton.setVisibility(visibility_settings_sync_video); // still allow exposure lock when recording video
                 if( showWhiteBalanceLockIcon() )
                     whiteBalanceLockButton.setVisibility(visibility_video); // still allow white balance lock when recording video
                 if( showCycleRawIcon() )
@@ -1268,7 +1279,7 @@ public class MainUI {
                         Log.d(TAG, "Remote control DISconnected");
                     remoteConnectedIcon.setVisibility(View.GONE);
                 }
-                popupButton.setVisibility(main_activity.getPreview().supportsFlash() ? visibility_video : visibility); // still allow popup in order to change flash mode when recording video
+                popupButton.setVisibility(main_activity.getPreview().supportsFlash() ? visibility_settings_sync_video : visibility_settings_sync); // still allow popup in order to change flash mode when recording video
 
                 layoutUI(); // needed for "top" UIPlacement, to auto-arrange the buttons
             }


### PR DESCRIPTION
RecSync workflow is changed with recording start divided into two stages:
1. Video preparation (up to and including the `camera_controller.initVideoRecorderPostPrepare` call)
2. Recording start (after the `camera_controller.initVideoRecorderPostPrepare` call)

Related fixed bugs:
- When a client connects to a leader which has settings sync enabled, the client either gets an app crash ar a camera error.
  - Solution: video recording preparation was programmed to start each time the camera reopens but only if `SoftwareSyncController`'s field `mIsVideoPreparationNeeded` equals `false` -- the problems was that this field was set to `true` before settings sync (which might reopen the camera) finishes, so the preparation was starting before settings sync finishes and it led to crashes.
- When settings sync is started the second time it never finishes.
  - Solution: `applyAndLockSettings()` has been incorrectly determining the need for a camera reopening.
- Settings sync never truly finishes (i.e. with the `onFinished()` invocation being finished) when started from the "Sync settings" button click.
  - Solution: `Preview,prepareVideoRecording()` call needs to be made inside a `MainActivity.runOnUiThread()` block, or otherwise call that need a `Looper` (such as [this one](https://github.com/MobileRoboticsSkoltech/OpenCamera-Sensors/blob/3122e4f97e046924839956eb3303c9993c0201cd/app/src/main/java/net/sourceforge/opencamera/cameracontroller/CameraController2.java#L7241)) cannot be executed.
- Clients sometimes have camera errors when settings sync is cancelled (specifically, when the recording preparation is cancelled).
  - Solution: `Preview.stopVideo()` call needs to be made inside a `MainActivity.runOnUiThread()` block (with the same reasoning as above).