### PR TITLE
Fixes of RecSync replated to unused video files

### DIFF
--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -59,9 +59,9 @@ public class SoftwareSyncController implements Closeable {
     private static final String TAG = "SoftwareSyncController";
 
     private final MainActivity mMainActivity;
-    private final SoftwareSyncUtils mSoftwareSyncUtils;
     private final PhaseAlignController mPhaseAlignController;
     private final PeriodCalculator mPeriodCalculator;
+    private final SoftwareSyncUtils mSoftwareSyncUtils;
     private String mSyncStatus;
     private SoftwareSyncBase mSoftwareSync;
     private AlignPhasesTask mAlignPhasesTask;
@@ -114,9 +114,9 @@ public class SoftwareSyncController implements Closeable {
     public SoftwareSyncController(
             MainActivity mainActivity, PhaseAlignController phaseAlignController, PeriodCalculator periodCalculator) {
         mMainActivity = mainActivity;
-        mSoftwareSyncUtils = mainActivity.getApplicationInterface().getSoftwareSyncUtils();
         mPhaseAlignController = phaseAlignController;
         mPeriodCalculator = periodCalculator;
+        mSoftwareSyncUtils = new SoftwareSyncUtils(mainActivity, this);
 
         setupSoftwareSync();
     }
@@ -499,6 +499,10 @@ public class SoftwareSyncController implements Closeable {
             mPeriodCalculator.onFrameTimestamp(timestamp);
         }
         mPhaseAlignController.updateCaptureTimestamp(mSoftwareSync.leaderTimeForLocalTimeNs(timestamp));
+    }
+
+    public SoftwareSyncUtils getSoftwareSyncUtils() {
+        return mSoftwareSyncUtils;
     }
 
     public SoftwareSyncBase getSoftwareSync() {

--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -39,7 +39,7 @@ import com.googleresearch.capturesync.softwaresync.phasealign.PeriodCalculator;
 
 import net.sourceforge.opencamera.MainActivity;
 import net.sourceforge.opencamera.R;
-import net.sourceforge.opencamera.recsync.SoftwareSyncUtils;
+import net.sourceforge.opencamera.recsync.SoftwareSyncHelper;
 import net.sourceforge.opencamera.recsync.SyncSettingsContainer;
 
 import java.io.Closeable;
@@ -61,7 +61,7 @@ public class SoftwareSyncController implements Closeable {
     private final MainActivity mMainActivity;
     private final PhaseAlignController mPhaseAlignController;
     private final PeriodCalculator mPeriodCalculator;
-    private final SoftwareSyncUtils mSoftwareSyncUtils;
+    private final SoftwareSyncHelper mSoftwareSyncHelper;
     private String mSyncStatus;
     private SoftwareSyncBase mSoftwareSync;
     private AlignPhasesTask mAlignPhasesTask;
@@ -116,7 +116,7 @@ public class SoftwareSyncController implements Closeable {
         mMainActivity = mainActivity;
         mPhaseAlignController = phaseAlignController;
         mPeriodCalculator = periodCalculator;
-        mSoftwareSyncUtils = new SoftwareSyncUtils(mainActivity, this);
+        mSoftwareSyncHelper = new SoftwareSyncHelper(mainActivity, this);
 
         setupSoftwareSync();
     }
@@ -211,8 +211,8 @@ public class SoftwareSyncController implements Closeable {
 
                     if (settings != null) {
                         mState = State.SETTINGS_APPLICATION;
-                        mSoftwareSyncUtils.applyAndLockSettings(settings, () -> {
-                            mSoftwareSyncUtils.prepareVideoRecording();
+                        mSoftwareSyncHelper.applyAndLockSettings(settings, () -> {
+                            mSoftwareSyncHelper.prepareVideoRecording();
                             mIsVideoPreparationNeeded = true;
                             Log.d(TAG, "Settings application finished");
                             mState = State.IDLE;
@@ -227,7 +227,7 @@ public class SoftwareSyncController implements Closeable {
                     Log.d(TAG, "Request to clear video recording preparation received.");
 
                     mIsVideoPreparationNeeded = false;
-                    mSoftwareSyncUtils.removeVideoRecordingPreparation();
+                    mSoftwareSyncHelper.removeVideoRecordingPreparation();
                 });
 
         // Switch the recording status (start or stop video recording) to the opposite of the received one.
@@ -255,7 +255,7 @@ public class SoftwareSyncController implements Closeable {
                             });
                         } else { // Need to start recording.
                             mState = State.RECORDING;
-                            if (!mSoftwareSyncUtils.startPreparedVideoRecording()) {
+                            if (!mSoftwareSyncHelper.startPreparedVideoRecording()) {
                                 mState = State.IDLE;
                                 // TODO: inform user that preparation is required.
                             }
@@ -285,7 +285,7 @@ public class SoftwareSyncController implements Closeable {
             clientRpcs.put(
                     SyncConstants.METHOD_MSG_WAITING_FOR_LEADER,
                     payload -> {
-                        mSoftwareSyncUtils.removeVideoRecordingPreparation();
+                        mSoftwareSyncHelper.removeVideoRecordingPreparation();
                         mIsVideoPreparationNeeded = false;
                         mMainActivity.runOnUiThread(
                                 () -> mSyncStatus = mMainActivity.getString(R.string.rec_sync_waiting_for_leader, mSoftwareSync.getName()));
@@ -501,8 +501,8 @@ public class SoftwareSyncController implements Closeable {
         mPhaseAlignController.updateCaptureTimestamp(mSoftwareSync.leaderTimeForLocalTimeNs(timestamp));
     }
 
-    public SoftwareSyncUtils getSoftwareSyncUtils() {
-        return mSoftwareSyncUtils;
+    public SoftwareSyncHelper getSoftwareSyncUtils() {
+        return mSoftwareSyncHelper;
     }
 
     public SoftwareSyncBase getSoftwareSync() {

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -24,7 +24,7 @@ import com.googleresearch.capturesync.softwaresync.phasealign.PeriodCalculator;
 import com.googleresearch.capturesync.softwaresync.phasealign.PhaseConfig;
 
 import net.sourceforge.opencamera.cameracontroller.YuvImageUtils;
-import net.sourceforge.opencamera.recsync.SoftwareSyncUtils;
+import net.sourceforge.opencamera.recsync.SoftwareSyncHelper;
 import net.sourceforge.opencamera.sensorlogging.FlashController;
 import net.sourceforge.opencamera.sensorlogging.RawSensorInfo;
 import net.sourceforge.opencamera.sensorlogging.VideoFrameInfo;
@@ -58,7 +58,7 @@ public class ExtendedAppInterface extends MyApplicationInterface {
     private final PreferenceHandler mPrefs;
 
     private SoftwareSyncController mSoftwareSyncController;
-    private SoftwareSyncUtils mSoftwareSyncUtils;
+    private SoftwareSyncHelper mSoftwareSyncHelper;
     private BroadcastReceiver mConnectionStatusChecker = null;
 
     ExtendedAppInterface(MainActivity mainActivity, Bundle savedInstanceState) {
@@ -114,8 +114,8 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         return mSoftwareSyncController;
     }
 
-    public SoftwareSyncUtils getSoftwareSyncUtils() {
-        return mSoftwareSyncUtils;
+    public SoftwareSyncHelper getSoftwareSyncUtils() {
+        return mSoftwareSyncHelper;
     }
 
     public YuvImageUtils getYuvUtils() {
@@ -158,11 +158,11 @@ public class ExtendedAppInterface extends MyApplicationInterface {
     public void cameraOpened() {
         if (isSoftwareSyncRunning()) {
             if (mSoftwareSyncController.isVideoPreparationNeeded()) {
-                mSoftwareSyncUtils.prepareVideoRecording();
+                mSoftwareSyncHelper.prepareVideoRecording();
             }
 
             // Should be at the end of this method as it may close the camera
-            final Runnable applySettingsRunnable = mSoftwareSyncUtils.getApplySettingsRunnable();
+            final Runnable applySettingsRunnable = mSoftwareSyncHelper.getApplySettingsRunnable();
             if (applySettingsRunnable != null) {
                 applySettingsRunnable.run();
             }
@@ -265,7 +265,7 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         // Prepare to the next recording
         if (isSoftwareSyncRunning() && mSoftwareSyncController.isVideoPreparationNeeded()
                 && !mMainActivity.isAppPaused() && !mMainActivity.isSettingsActive()) {
-            mSoftwareSyncUtils.prepareVideoRecording();
+            mSoftwareSyncHelper.prepareVideoRecording();
         }
     }
 
@@ -345,7 +345,7 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         }
         mMainActivity.registerReceiver(mConnectionStatusChecker, intentFilter);
 
-        mSoftwareSyncUtils = mSoftwareSyncController.getSoftwareSyncUtils();
+        mSoftwareSyncHelper = mSoftwareSyncController.getSoftwareSyncUtils();
     }
 
     private class HotspotStatusChecker extends BroadcastReceiver {
@@ -415,7 +415,7 @@ public class ExtendedAppInterface extends MyApplicationInterface {
     public void stopSoftwareSync() {
         if (isSoftwareSyncRunning()) {
             mMainActivity.unregisterReceiver(mConnectionStatusChecker);
-            mSoftwareSyncUtils = null;
+            mSoftwareSyncHelper = null;
             mConnectionStatusChecker = null;
             mSoftwareSyncController.close();
             mSoftwareSyncController = null;

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -343,7 +343,7 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         }
         mMainActivity.registerReceiver(mConnectionStatusChecker, intentFilter);
 
-        mSoftwareSyncUtils = new SoftwareSyncUtils(mMainActivity);
+        mSoftwareSyncUtils = mSoftwareSyncController.getSoftwareSyncUtils();
     }
 
     private class HotspotStatusChecker extends BroadcastReceiver {

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -258,11 +258,9 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         }
     }
 
-    @Override
-    public void stoppedVideo(VideoMethod video_method, Uri uri, String filename) {
-        super.stoppedVideo(video_method, uri, filename);
-
+    public void finishedVideo() {
         // Prepare to the next recording
+        // TODO: check that settings are not being opened and the app is not pausing
         if (mSoftwareSyncController.isVideoPreparationNeeded())
             mSoftwareSyncUtils.prepareVideoRecording();
     }

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -8,7 +8,6 @@ import android.content.IntentFilter;
 import android.hardware.Sensor;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -259,10 +258,15 @@ public class ExtendedAppInterface extends MyApplicationInterface {
     }
 
     public void finishedVideo() {
+        if (MyDebug.LOG) {
+            Log.d(TAG, "finished video");
+        }
+
         // Prepare to the next recording
-        // TODO: check that settings are not being opened and the app is not pausing
-        if (mSoftwareSyncController.isVideoPreparationNeeded())
+        if (isSoftwareSyncRunning() && mSoftwareSyncController.isVideoPreparationNeeded()
+                && !mMainActivity.isAppPaused() && !mMainActivity.isSettingsActive()) {
             mSoftwareSyncUtils.prepareVideoRecording();
+        }
     }
 
     public void onFrameInfoRecordingFailed() {

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1552,7 +1552,8 @@ public class MainActivity extends Activity {
         // clear RecSync related state
         if( applicationInterface.isSoftwareSyncRunning() ) {
             applicationInterface.getSoftwareSyncController().clearPeriodState();
-            applicationInterface.getSoftwareSyncUtils().removeVideoRecordingPreparation();
+            if( !preview.isVideoRecording() )
+                applicationInterface.getSoftwareSyncUtils().removeVideoRecordingPreparation();
         }
 
         // Stop Remote controller for OpenCamera Sensors
@@ -2462,7 +2463,8 @@ public class MainActivity extends Activity {
 
         if( applicationInterface.isSoftwareSyncRunning() ) {
             applicationInterface.getSoftwareSyncController().clearPeriodState();
-            applicationInterface.getSoftwareSyncUtils().removeVideoRecordingPreparation();
+            if( !preview.isVideoRecording() ) // need to check because video is stopped concurrently
+                applicationInterface.getSoftwareSyncUtils().removeVideoRecordingPreparation();
         }
 
         Bundle bundle = new Bundle();

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -115,6 +115,7 @@ public class MainActivity extends Activity {
     private static int activity_count = 0;
 
     private boolean app_is_paused = true;
+    private boolean settings_is_active = false;
 
     private SensorManager mSensorManager;
     private Sensor mSensorAccelerometer;
@@ -2452,6 +2453,9 @@ public class MainActivity extends Activity {
     public void openSettings() {
         if( MyDebug.LOG )
             Log.d(TAG, "openSettings");
+
+        settings_is_active = true;
+
         closePopup();
         preview.cancelTimer(); // best to cancel any timer, in case we take a photo while settings window is open, or when changing settings
         preview.cancelRepeat(); // similarly cancel the auto-repeat mode!
@@ -3010,6 +3014,8 @@ public class MainActivity extends Activity {
                 mainUI.destroyPopup();
             }
         }
+
+        settings_is_active = false;
     }
 
     @Override
@@ -5133,6 +5139,10 @@ public class MainActivity extends Activity {
 
     public boolean isAppPaused() {
         return this.app_is_paused;
+    }
+
+    public boolean isSettingsActive() {
+        return this.settings_is_active;
     }
 
     public BluetoothRemoteControl getBluetoothRemoteControl() {

--- a/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
+++ b/app/src/main/java/net/sourceforge/opencamera/preview/Preview.java
@@ -1081,6 +1081,8 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
         }
         videoFileInfo = new VideoFileInfo();
         nextVideoFileInfo = null;
+
+        applicationInterface.finishedVideo();
     }
 
     private Context getContext() {

--- a/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncHelper.java
+++ b/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncHelper.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class SoftwareSyncUtils {
-    private static final String TAG = "SoftwareSyncUtils";
+public class SoftwareSyncHelper {
+    private static final String TAG = "SoftwareSyncHelper";
 
     private final MainActivity mMainActivity;
     private final ExtendedAppInterface mApplicationInterface;
@@ -31,7 +31,7 @@ public class SoftwareSyncUtils {
 
     private Runnable mApplySettingsRunnable = null;
 
-    public SoftwareSyncUtils(MainActivity mainActivity, SoftwareSyncController softwareSyncController) {
+    public SoftwareSyncHelper(MainActivity mainActivity, SoftwareSyncController softwareSyncController) {
         mMainActivity = mainActivity;
         mSoftwareSyncController = softwareSyncController;
         mApplicationInterface = mMainActivity.getApplicationInterface();

--- a/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
+++ b/app/src/main/java/net/sourceforge/opencamera/recsync/SoftwareSyncUtils.java
@@ -31,11 +31,11 @@ public class SoftwareSyncUtils {
 
     private Runnable mApplySettingsRunnable = null;
 
-    public SoftwareSyncUtils(MainActivity mainActivity) {
+    public SoftwareSyncUtils(MainActivity mainActivity, SoftwareSyncController softwareSyncController) {
         mMainActivity = mainActivity;
+        mSoftwareSyncController = softwareSyncController;
         mApplicationInterface = mMainActivity.getApplicationInterface();
         mPreview = mMainActivity.getPreview();
-        mSoftwareSyncController = mApplicationInterface.getSoftwareSyncController();
     }
 
     public Runnable getApplySettingsRunnable() {


### PR DESCRIPTION
Because of the new two-staged video recording scheme video files may be created even if the recording is not going to be started. Such files remain unused and need to be deleted manually. That is what changes from this PR do.