### PR TITLE
RecSync workflow fixes

### DIFF
--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -228,6 +228,7 @@ public class SoftwareSyncController implements Closeable {
                     Log.d(TAG, "Request to clear video recording preparation received.");
 
                     mPhaseAlignController.stopAlign();
+                    clearPeriodState();
                     mIsVideoPreparationNeeded = false;
                     mSoftwareSyncHelper.removeVideoRecordingPreparation();
                     mMainActivity.getMainUI().reloadButtons();

--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -216,6 +216,7 @@ public class SoftwareSyncController implements Closeable {
                             mIsVideoPreparationNeeded = true;
                             Log.d(TAG, "Settings application finished");
                             mState = State.IDLE;
+                            mMainActivity.getMainUI().reloadButtons();
                         });
                     }
                 });
@@ -228,6 +229,7 @@ public class SoftwareSyncController implements Closeable {
 
                     mIsVideoPreparationNeeded = false;
                     mSoftwareSyncHelper.removeVideoRecordingPreparation();
+                    mMainActivity.getMainUI().reloadButtons();
                 });
 
         // Switch the recording status (start or stop video recording) to the opposite of the received one.

--- a/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
+++ b/app/src/main/java/com/googleresearch/capturesync/SoftwareSyncController.java
@@ -227,6 +227,7 @@ public class SoftwareSyncController implements Closeable {
                 payload -> {
                     Log.d(TAG, "Request to clear video recording preparation received.");
 
+                    mPhaseAlignController.stopAlign();
                     mIsVideoPreparationNeeded = false;
                     mSoftwareSyncHelper.removeVideoRecordingPreparation();
                     mMainActivity.getMainUI().reloadButtons();

--- a/app/src/main/java/com/googleresearch/capturesync/softwaresync/phasealign/PeriodCalculator.java
+++ b/app/src/main/java/com/googleresearch/capturesync/softwaresync/phasealign/PeriodCalculator.java
@@ -4,12 +4,14 @@
 
 package com.googleresearch.capturesync.softwaresync.phasealign;
 
+import android.content.Context;
 import android.os.Build;
 
 import androidx.annotation.RequiresApi;
 
-import net.sourceforge.opencamera.MainActivity;
 import net.sourceforge.opencamera.R;
+import net.sourceforge.opencamera.ToastBoxer;
+import net.sourceforge.opencamera.preview.Preview;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,12 +22,17 @@ import java.util.stream.Collectors;
 public class PeriodCalculator {
     private final static long CALC_DURATION_MS = 10000;
 
-    private final MainActivity mMainActivity;
+    private final Context mContext;
+    private final Preview mPreview;
+    private final ToastBoxer mToastBoxer;
+
     private volatile boolean mShouldRegister;
     private ArrayList<Long> mRegisteredTimestamps = new ArrayList<>();
 
-    public PeriodCalculator(MainActivity mainActivity) {
-        mMainActivity = mainActivity;
+    public PeriodCalculator(Context context, Preview preview, ToastBoxer toastBoxer) {
+        mContext = context;
+        mPreview = preview;
+        mToastBoxer = toastBoxer;
     }
 
     /**
@@ -39,7 +46,7 @@ public class PeriodCalculator {
      */
     @RequiresApi(api = Build.VERSION_CODES.N)
     public long getPeriodNs() throws InterruptedException {
-        mMainActivity.getPreview().showToast(mMainActivity.getRecSyncToastBoxer(), mMainActivity.getString(R.string.calculating_period, CALC_DURATION_MS * 1e-3));
+        mPreview.showToast(mToastBoxer, mContext.getString(R.string.calculating_period, CALC_DURATION_MS * 1e-3));
         // Start recording timestamps
         mRegisteredTimestamps = new ArrayList<>();
         mShouldRegister = true;

--- a/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ExtendedAppInterface.java
@@ -53,12 +53,12 @@ public class ExtendedAppInterface extends MyApplicationInterface {
     private final FlashController mFlashController;
     private final MainActivity mMainActivity;
     private final YuvImageUtils mYuvUtils;
-    private final PhaseAlignController mPhaseAlignController;
-    private final PeriodCalculator mPeriodCalculator;
     private final PreferenceHandler mPrefs;
 
     private SoftwareSyncController mSoftwareSyncController;
     private SoftwareSyncHelper mSoftwareSyncHelper;
+    private PhaseAlignController mPhaseAlignController;
+    private PeriodCalculator mPeriodCalculator;
     private BroadcastReceiver mConnectionStatusChecker = null;
 
     ExtendedAppInterface(MainActivity mainActivity, Bundle savedInstanceState) {
@@ -69,8 +69,6 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         // We create it only once here (not during the video) as it is a costly operation
         // (instantiates RenderScript object)
         mYuvUtils = new YuvImageUtils(mainActivity);
-        mPhaseAlignController = new PhaseAlignController(getDefaultPhaseConfig(), mainActivity);
-        mPeriodCalculator = new PeriodCalculator(mainActivity);
         mPrefs = new PreferenceHandler(mainActivity);
     }
 
@@ -312,6 +310,11 @@ public class ExtendedAppInterface extends MyApplicationInterface {
         // Start softwaresync, close it first if it's already running.
         if (isSoftwareSyncRunning()) {
             stopSoftwareSync();
+        } else {
+            mPhaseAlignController = new PhaseAlignController(getDefaultPhaseConfig(), mMainActivity,
+                    mMainActivity.getPreview(), mMainActivity.getRecSyncToastBoxer());
+            mPeriodCalculator = new PeriodCalculator(mMainActivity, mMainActivity.getPreview(),
+                    mMainActivity.getRecSyncToastBoxer());
         }
 
         try {

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1817,14 +1817,6 @@ public class MainActivity extends Activity {
             Log.d(TAG, "clickedSyncSettings");
         syncSettings();
         mainUI.updateSyncSettingsIcon();
-
-        // need to update button visibility
-        if( mainUI.inImmersiveMode() ) {
-            mainUI.setImmersiveMode(true);
-        } else {
-            mainUI.showGUI();
-        }
-        mainUI.layoutUI();
     }
 
     public void syncSettings() {

--- a/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
+++ b/app/src/main/java/net/sourceforge/opencamera/MainActivity.java
@@ -1835,7 +1835,6 @@ public class MainActivity extends Activity {
             applicationInterface.getSoftwareSyncUtils().broadcastSettings(settings); // leader's settings are locked here as well
             preview.showToast(rec_sync_toast, R.string.settings_broadcast_started);
         } else {
-            softwareSyncController.clearPeriodState();
             applicationInterface.getSoftwareSyncUtils().broadcastClearVideoPreparationRequest();
         }
 

--- a/app/src/main/java/net/sourceforge/opencamera/cameracontroller/CameraController2.java
+++ b/app/src/main/java/net/sourceforge/opencamera/cameracontroller/CameraController2.java
@@ -7452,6 +7452,8 @@ public class CameraController2 extends CameraController {
             Log.wtf(TAG, "Failed to add surfaces for frame injection builder", e); // wtf bcs videoRecorder is null
         }
 
+        Log.i(TAG, String.format("Current exposure: %.6f ms, inserting frame with exposure %.6f ms", getExposureTime() * 1e-6f, desiredExposureTimeNs * 1e-6f));
+
         // the alignment fails when using the preconfigured previewCaptureCallback
         synchronized( background_camera_lock ) {
             if( captureSession == null ) {

--- a/app/src/main/java/net/sourceforge/opencamera/ui/MainUI.java
+++ b/app/src/main/java/net/sourceforge/opencamera/ui/MainUI.java
@@ -1060,6 +1060,15 @@ public class MainUI {
         return sharedPreferences.getBoolean(PreferenceKeys.ShowFaceDetectionPreferenceKey, false);
     }
 
+    public void reloadButtons() {
+        if( inImmersiveMode() ) {
+            setImmersiveMode(true);
+        } else {
+            showGUI();
+        }
+        layoutUI();
+    }
+
     public void setImmersiveMode(final boolean immersive_mode) {
         if( MyDebug.LOG )
             Log.d(TAG, "setImmersiveMode: " + immersive_mode);
@@ -1071,10 +1080,16 @@ public class MainUI {
                 //final int visibility_gone = immersive_mode ? View.GONE : View.VISIBLE;
                 final int visibility = immersive_mode ? View.GONE : View.VISIBLE;
                 final int visibility_settings_sync; // for UI that is hidden when settings are being broadcast
+                final int visibility_align_phases; // for the phase alignment UI
                 {
                     ExtendedAppInterface extendedAppInterface = main_activity.getApplicationInterface();
                     SoftwareSyncController softwareSyncController = extendedAppInterface.getSoftwareSyncController();
-                    visibility_settings_sync = extendedAppInterface.isSoftwareSyncRunning() && softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting() ? View.GONE : visibility;
+                    visibility_settings_sync = extendedAppInterface.isSoftwareSyncRunning() &&
+                            softwareSyncController.isVideoPreparationNeeded() ?
+                            View.GONE : visibility;
+                    visibility_align_phases = extendedAppInterface.isSoftwareSyncRunning() &&
+                            softwareSyncController.isLeader() && softwareSyncController.isVideoPreparationNeeded() ?
+                            visibility : View.GONE;
                 }
                 if( MyDebug.LOG )
                     Log.d(TAG, "setImmersiveMode: set visibility: " + visibility);
@@ -1110,7 +1125,7 @@ public class MainUI {
                 if( main_activity.supportsExposureButton() )
                     exposureButton.setVisibility(visibility_settings_sync);
                 if( showAlignPhasesIcon() )
-                    alignPhasesButton.setVisibility(visibility_settings_sync == View.GONE ? visibility : View.GONE); // is shown when settings are being broadcast
+                    alignPhasesButton.setVisibility(visibility_align_phases); // is shown to a leader when prepared without recording
                 if( showExposureLockIcon() )
                     exposureLockButton.setVisibility(visibility_settings_sync);
                 if( showWhiteBalanceLockIcon() )
@@ -1211,11 +1226,19 @@ public class MainUI {
                 final int visibility_video = is_panorama_recording ? View.GONE : show_gui_photo ? View.VISIBLE : View.GONE; // for UI that is only hidden while taking photo
                 final int visibility_settings_sync; // for UI that is hidden while taking photo or video and when settings are being broadcast
                 final int visibility_settings_sync_video; // for UI that is hidden while taking photo and when settings are being broadcast
+                final int visibility_align_phases; // for the phase alignment UI
                 {
                     ExtendedAppInterface extendedAppInterface = main_activity.getApplicationInterface();
                     SoftwareSyncController softwareSyncController = extendedAppInterface.getSoftwareSyncController();
-                    visibility_settings_sync = extendedAppInterface.isSoftwareSyncRunning() && softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting() ? View.GONE : visibility;
-                    visibility_settings_sync_video = extendedAppInterface.isSoftwareSyncRunning() && softwareSyncController.isLeader() && softwareSyncController.isSettingsBroadcasting() ? View.GONE : visibility_video;
+                    visibility_settings_sync = extendedAppInterface.isSoftwareSyncRunning() &&
+                            softwareSyncController.isVideoPreparationNeeded() ?
+                            View.GONE : visibility;
+                    visibility_settings_sync_video = extendedAppInterface.isSoftwareSyncRunning() &&
+                            softwareSyncController.isVideoPreparationNeeded() ?
+                            View.GONE : visibility_video;
+                    visibility_align_phases = extendedAppInterface.isSoftwareSyncRunning() &&
+                            softwareSyncController.isLeader() && softwareSyncController.isVideoPreparationNeeded() ?
+                            visibility : View.GONE;
                 }
                 View switchCameraButton = main_activity.findViewById(R.id.switch_camera);
                 View switchMultiCameraButton = main_activity.findViewById(R.id.switch_multi_camera);
@@ -1242,7 +1265,7 @@ public class MainUI {
                 if( main_activity.supportsExposureButton() )
                     exposureButton.setVisibility(visibility_settings_sync_video); // still allow exposure when recording video
                 if( showAlignPhasesIcon() )
-                    alignPhasesButton.setVisibility(visibility_settings_sync == View.GONE ? visibility : View.GONE); // is shown when settings are being broadcast
+                    alignPhasesButton.setVisibility(visibility_align_phases); // is shown to a leader when prepared without recording
                 if( showExposureLockIcon() )
                     exposureLockButton.setVisibility(visibility_settings_sync_video); // still allow exposure lock when recording video
                 if( showWhiteBalanceLockIcon() )


### PR DESCRIPTION
The following issues are fixed:
- Timestamp logging not working in RecSync mode
- Top menu on client smartphones not updating correctly after the initiation of the video recording preparation
- Phase alignment continuing even after the video recording preparation is discarded
- Calculated period not being cleared on client smartphones when the video recording preparation is discarded