### PR TITLE
Add latest version changelog to fastlane metadata

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/81.txt
+++ b/fastlane/metadata/android/en-US/changelogs/81.txt
@@ -1,0 +1,1 @@
+Added RecSync functionality (synchronized video recording on multiple smartphones).


### PR DESCRIPTION
Adds changlelog for version `1.48.3.1` (version code 81) to fastlane metadata. Required for F-Droid integration.